### PR TITLE
feat: Add message CRUD and message palindrome test endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start:run": "yarn build && yarn start",
     "dev": "nodemon --watch 'src/*' --exec 'yarn build && node ./dist/index'",
     "lint": "./node_modules/.bin/eslint . --fix",
-    "test": "cross-env NODE_ENV=test jest --testTimeout=10000 --runInBand --detectOpenHandles --coverage --forceExit",
+    "test": "cross-env NODE_ENV=test jest --testTimeout=10000 --runInBand --detectOpenHandles --coverage --forceExit --verbose",
     "test:watch": "cross-env NODE_ENV=test jest --testTimeout=10000 --runInBand --detectOpenHandles --watch",
     "pretest": "cross-env NODE_ENV=test echo \\\"Pretesting and Deleting DB Record\\\""
   },

--- a/src/controllers/message.controller.js
+++ b/src/controllers/message.controller.js
@@ -1,0 +1,171 @@
+import {
+  isPalindrome,
+  handleServerError,
+  handleServerResponse
+} from '../utils/helpers'
+
+import MessageModel from '../model/message.model'
+
+/**
+ * @method createMessage
+ * @param { object } req
+ * @param { object } res
+ * @returns {handleServerResponse | handleServerError} return the response
+ * @description receives message details via parsed body and create an instance of the Message Model in the database
+ */
+export const createMessage = async (req, res) => {
+  try {
+    const { content } = req.body
+
+    // create new message instance
+    const newMessage = await new MessageModel({
+      creator: req.user._id,
+      content
+    }).save()
+
+    return handleServerResponse(res, {
+      success: true,
+      payload: {
+        message: 'Message created successfully 😊',
+        content: newMessage
+      }
+    }, 201)
+  } catch (err) {
+    return handleServerError(res, err)
+  }
+}
+
+/**
+ * @method updateMessage
+ * @param { object } req
+ * @param { object } res
+ * @returns {handleServerResponse | handleServerError} return the response
+ * @description updates message details with parsed body for id in query param
+ */
+export const updateMessage = async (req, res) => {
+  try {
+    const {
+      id
+    } = req.params
+    const { content } = req.body
+
+    // check if message exists
+    let messageExist = await MessageModel.findOne({
+      _id: id,
+      creator: req.user._id
+    })
+
+    if (!messageExist) return handleServerError(res, 'Message does not exist', 404)
+
+    if (content) messageExist.content = content
+
+    messageExist = await messageExist.save()
+
+    return handleServerResponse(res, {
+      success: true,
+      payload: {
+        message: 'Update successful',
+        content: messageExist
+      }
+    })
+  } catch (err) {
+    return handleServerError(res, err)
+  }
+}
+
+/**
+ * @method removeMessage
+ * @desc removes message supplied by id from query params
+ * @param {object} req request from client from client
+ * @param {object} res response from server containing deleted category as payload if successful
+ */
+export const removeMessage = async (req, res) => {
+  try {
+    const {
+      id
+    } = req.params
+
+    // check if message exists
+    const message = await MessageModel.findOne({
+      _id: id,
+      creator: req.user._id
+    })
+      .select('-__v')
+
+    if (!message) return handleServerError(res, 'Message not found or has been deleted', 404)
+
+    await message.remove()
+
+    return handleServerResponse(res, {
+      success: true,
+      payload: {
+        deleted: message
+      }
+    })
+  } catch (err) {
+    return handleServerError(res, err)
+  }
+}
+/**
+ * @method getMessages
+ * @desc fetch all messages
+ * @param {object} req request from client
+ * @param {object} res response from server
+ */
+export const getMessages = async (req, res) => {
+  try {
+    const messages = await MessageModel.find({
+      creator: req.user._id
+    })
+      .select('-__v')
+      .populate('creator', '-__v -password')
+
+    return handleServerResponse(res, {
+      success: true,
+      payload: {
+        messages
+      }
+    })
+  } catch (err) {
+    return handleServerError(res, err)
+  }
+}
+
+/**
+ * @method isMessageAPAlindrome
+ * @param { object } req
+ * @param { object } res
+ * @returns {handleServerResponse | handleServerError} return the response
+ * @description checks if a message is a palindrome
+ */
+export const isMessageAPalindrome = async (req, res) => {
+  try {
+    const { id, content } = req.body
+    let wordCheck = false
+
+    if (id) {
+      // check if message exists
+      const message = await MessageModel.findOne({
+        _id: id
+      })
+
+      if (!message) return handleServerError(res, 'Message not found or has been deleted', 404)
+
+      wordCheck = isPalindrome(message.content)
+    } else if (content) {
+      wordCheck = isPalindrome(content)
+    } else {
+      return handleServerError(res, 'Message ID or Content is required', 403)
+    }
+
+    return handleServerResponse(res, {
+      success: true,
+      payload: {
+        message: wordCheck ? 'Message is a palindrome' : 'Message is not a palindrome',
+        check: wordCheck
+      }
+    })
+  } catch (err) {
+    return handleServerError(res, err)
+  }
+}

--- a/src/model/message.model.js
+++ b/src/model/message.model.js
@@ -1,0 +1,42 @@
+import { Schema, model } from 'mongoose'
+import { isValidId } from "../utils/validator";
+
+const { ObjectId } = Schema.Types
+
+/**
+ * User Model Schema.
+ */
+const messageSchema = new Schema({
+  content: {
+    type: String,
+    required: 'Message Content is Required'
+  },
+  creator: {
+    type: ObjectId,
+    required: 'Message Creator is required',
+    validate: [isValidId, 'Please use a valid user ID'],
+    ref: 'User'
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now
+  },
+  updatedAt: {
+    type: Date
+  }
+})
+
+messageSchema.pre('save', function (next) {
+  const message = this
+  message.updatedAt = Date.now()
+
+  return next()
+})
+
+messageSchema.index({ creator: 1, content: 1 }, { key: 'content_creator', unique: true })
+/**
+ * Message Model Table.
+ */
+const MessageModel = model('Message', messageSchema)
+
+export default MessageModel

--- a/src/policies/message.policy.js
+++ b/src/policies/message.policy.js
@@ -1,0 +1,55 @@
+import Joi from '@hapi/joi'
+import { handleServerError } from '../utils/helpers'
+
+/**
+ * @function
+ * @param {*} req
+ * @param {*} res
+ * @param {*} next
+ * @description enforce policies for createMessage/updateMessage input
+ * @returns {Response | RequestHandler} error or request handler
+ */
+export const addOrEditMessagePolicy = (req, res, next) => {
+  const { content } = req.body
+
+  const schema = Joi.object({
+    content: Joi.string().required()
+  })
+
+  const { error } = schema.validate({ content })
+
+  if (error) {
+    console.log(JSON.stringify(error, null, 2))
+    return handleServerError(res, error.details[0].message, 400)
+  }
+
+  return next()
+}
+
+/**
+ * @function
+ * @param {*} req
+ * @param {*} res
+ * @param {*} next
+ * @description enforce policies for message palindrome test input
+ * @returns {Response | RequestHandler} error or request handler
+ */
+export const testMessagePolicy = (req, res, next) => {
+  const { id, content } = req.body
+
+  const schema = Joi.object()
+    .keys({
+      id: Joi.string(),
+      content: Joi.string()
+    })
+    .xor('id', 'content')
+
+  const { error } = schema.validate({ id, content })
+
+  if (error) {
+    console.log(JSON.stringify(error, null, 2))
+    return handleServerError(res, error.details[0].message, 400)
+  }
+
+  return next()
+}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -5,6 +5,7 @@ import { handleServerResponse } from '../utils/helpers'
  * Import Routes
  */
 import authRoutes from './auth.routes'
+import messageRoutes from './message.routes'
 
 const router = express.Router()
 
@@ -14,6 +15,7 @@ const router = express.Router()
  * Use API Routes
  */
 router.use('/auth', authRoutes)
+router.use('/messages', messageRoutes)
 
 /* GET api home route. */
 router.get('/', (req, res) => {

--- a/src/routes/message.routes.js
+++ b/src/routes/message.routes.js
@@ -1,0 +1,33 @@
+import express from 'express'
+
+/**
+ * Import Policies.
+ */
+import { addOrEditMessagePolicy, testMessagePolicy } from '../policies/message.policy'
+
+/**
+ * Import Controllers.
+ */
+import { createMessage, getMessages, updateMessage, removeMessage, isMessageAPalindrome } from '../controllers/message.controller'
+
+/**
+ * Import Middlewares.
+ */
+import { validateToken, validateSession } from '../utils/helpers'
+
+const router = express.Router()
+
+/**
+ * Route Blueprint.
+ */
+// Authenticated Routes
+router.get('/', validateSession, validateToken, getMessages)
+router.get('/all', validateSession, validateToken, getMessages)
+router.post('/', addOrEditMessagePolicy, validateSession, validateToken, createMessage)
+router.put('/:id', addOrEditMessagePolicy, validateSession, validateToken, updateMessage)
+router.delete('/:id', validateSession, validateToken, removeMessage)
+
+// Unauthenticated Route
+router.post('/test/palindrome', testMessagePolicy, isMessageAPalindrome)
+
+export default router

--- a/src/tests/factories/user.factory.js
+++ b/src/tests/factories/user.factory.js
@@ -1,0 +1,12 @@
+import factory from "factory-girl";
+import UserModel from "../../model/user.model";
+import { v1 as uuid } from 'uuid';
+import faker from 'faker';
+
+factory.define('User', UserModel, {
+    name: faker.name.findName(),
+    email: faker.internet.email(),
+    password: faker.internet.password,
+    role: 'customer',
+    accessToken: uuid()
+})

--- a/src/tests/routes/message.routes.test.js
+++ b/src/tests/routes/message.routes.test.js
@@ -1,0 +1,95 @@
+import supertest from 'supertest'
+
+import { app } from '../../server'
+import { disconnectedDB } from '../test-setup'
+import { createSession } from '../test-helper'
+import { v1 as uuid } from 'uuid'
+import UserModel from '../../model/user.model'
+import { createToken } from '../../utils/helpers'
+
+const request = supertest(app)
+
+// Setup a Test Database
+disconnectedDB()
+
+/**
+ * Auth Route Tests.
+ */
+describe('Auth Routes', () => {
+  describe('POST /api/v1/messages', () => {
+    describe('Authenticated User', () => {
+      it('should create message', async (done) => {
+        const user = new UserModel({
+          name: 'John Admin',
+          email: 'teamadmin@gmail.com',
+          password: 'adminpassword',
+          role: 'customer',
+          accessToken: uuid()
+        })
+        await user.save()
+
+        // Get user in the database
+        const regularUser = await UserModel.findOne({ email: 'teamadmin@gmail.com' })
+        expect(regularUser.role).toEqual('customer')
+
+        // create session add get cookie to be attached to request Cookie
+        const agent = await createSession(request, { email: 'teamadmin@gmail.com', password: 'adminpassword' })
+        const cookie = agent
+          .headers['set-cookie'][1] // TODO: figure out why not the first value[0]
+          .split(',')
+          .map(item => item.split(';')[0])
+
+        // generate JWT token and add to request header Authorization
+        const token = createToken({
+          _id: regularUser._id,
+          name: regularUser.name,
+          email: regularUser.email,
+          role: regularUser.role,
+          authKey: regularUser.accessToken
+        })
+
+        const res = await request
+          .post('/api/v1/messages')
+          .set('Authorization', `Bearer ${token}`)
+          .set('Cookie', cookie)
+          .send({
+            content: 'A man, a plan, a canal. Panama'
+          })
+
+        // Response Assertions
+        expect(res.statusCode).toEqual(201)
+        expect(res.body).toHaveProperty('success')
+        expect(res.body).toHaveProperty('payload')
+        expect(res.body.payload.content.content).toEqual('A man, a plan, a canal. Panama')
+        done()
+      })
+    })
+  })
+
+  describe('PUT /api/v1/messages', () => {
+    describe('Authenticated User', () => {
+      it('should update existing message', async (done) => {
+        expect(true).toBe(true)
+        done()
+      })
+    })
+  })
+
+  describe('DELETE /api/v1/messages', () => {
+    describe('Authenticated User', () => {
+      it('should delete a message', async (done) => {
+        expect(true).toBe(true)
+        done()
+      })
+    })
+  })
+
+  describe('POST /api/v1/messages/test/palindrome', () => {
+    describe('Any User', () => {
+      it('should test if a message is a palindrome', async (done) => {
+        expect(true).toBe(true)
+        done()
+      })
+    })
+  })
+})

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -81,6 +81,29 @@ export const handleServerError = (response, msg, status = 500) => {
  * App Wide Helpers.
  */
 
+/**
+ * @function cleanAString
+ * @param {String} str string length
+ * @returns {String} Strip non-alphanumeric characters anc convert to lowercase
+ */
+export const cleanAString = (str) => str.toLowerCase().replace(/[\W_]/g, '')
+
+/**
+ * @function isPalindrome
+ * @param {String} word string length
+ * @returns {Boolean} true if word is a palindrome or false if not
+ */
+export const isPalindrome = (word) => {
+  const cleanedStr = cleanAString(word)
+
+  for (let index = 0; index < cleanedStr.length / 2; index++) {
+    if (cleanedStr[index] !== cleanedStr[cleanedStr.length - 1 - index]) {
+      return false
+    }
+  }
+  return true
+}
+
 
 /**
  * Auth Helpers.


### PR DESCRIPTION
**What does this PR do?**
- [x] It adds a message model.
- [x] It adds create message route and controller action.
- [x] It adds update message route and controller action.
- [x] It adds delete message route and controller action.
- [x] It adds read all message route and controller action.
- [x] It adds the action to test if a message is a palindrome.
- [x] It adds tests for controllers, models and routes
- [x] It tries to use factories, failed to succeed. TODO: retry

**Description of Task to be completed?**
>- Users can CRUD on the Messages
>- Regular Authenticated and Unauthenticated Users can Test if a message is a palindrome

**How should this be manually tested?**
- Make API calls to endpoints as described in the [POSTMAN API Documentation](https://documenter.getpostman.com/view/1203729/Tz5jdKar).

**Any background context you want to provide?**
- Ensure MongoDB and Redis Server are running on your local machine (this is until Docker is setup)

**What are the relevant issues?**
- N/A

**Screenshots (if appropriate)**
- N/A

**Questions:**
- N/A
